### PR TITLE
Make sure `postgres` user is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The PostgreSQL wiki has [installation
 guides](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for
 a number of different systems.
 
+Be sure that a `postgres` user is created; we'll be connecting to the database with that user. Newer versions of the Homebrew scripts don't create this user that out of the box. You can add the user manually, and give it the ability to create a new database:
+```console
+createuser -d postgres
+```
+
 ### inotify-tools (for linux users)
 
 This is a Linux-only filesystem watcher that Phoenix uses for live code


### PR DESCRIPTION
I had to do this to get `mix ecto.create` to work. Otherwise I got this error:

```
FATAL:  role "postgres" does not exist
** (Mix) The database for Support.Repo couldn't be created, reason given: "psql: FATAL:  role \"postgres\" does not exist\n".
```
